### PR TITLE
Fixed timer issue

### DIFF
--- a/Sources/GooglePlacesCell.swift
+++ b/Sources/GooglePlacesCell.swift
@@ -56,7 +56,7 @@ open class GooglePlacesCell: _FieldCell<GooglePlace>, CellType {
                 timer.invalidate()
                 autocompleteTimer = nil
             }
-            autocompleteTimer = Timer.scheduledTimer(timeInterval: 0.3, target: self, selector: #selector(GooglePlacesCell.timerFired(_:)), userInfo: nil, repeats: false)
+			autocompleteTimer = Timer.scheduledTimer(timeInterval: timerInterval, target: self, selector: #selector(GooglePlacesCell.timerFired(_:)), userInfo: nil, repeats: false)
         } else {
             autocomplete()
         }


### PR DESCRIPTION
I stumbled on this while working on the Row in general, it seems the autocomplete timer interval isn't being used for anything. This just uses the set value, by default there should be no change in behavior.